### PR TITLE
BugFix/#19348 db:migrate fails during installation due missign master.postgresql.service

### DIFF
--- a/resources/providers/config.rb
+++ b/resources/providers/config.rb
@@ -120,7 +120,12 @@ action :add do
       # Check if postgresql is registered to delete postgresql in /etc/hosts
       consul_response = `curl #{node['ipaddress']}:8500/v1/catalog/services 2>/dev/null | jq .postgresql`
       postgresql_registered = (consul_response == 'null\n' || consul_response == '') ? false : true
-      if postgresql_registered
+
+      # Check if any serf member has the leader=inprogress tag
+      serf_members_output = `serf members`
+      leader_inprogress = serf_members_output.include?('leader=inprogress')
+
+      if postgresql_registered && !leader_inprogress
         execute 'Removing postgresql service from /etc/hosts' do
           command "sed -i 's/.*postgresql.*//g' /etc/hosts"
         end


### PR DESCRIPTION
## Related issue in RedMine

- [Associated Redmine task](https://redmine.redborder.lan/issues/19348)

## Description

Dont remove `master.postgresql.service` during first node installation process.